### PR TITLE
修改签名方法，拼接xml时默认 使用cdata。用来消除特殊字符对xml的影响

### DIFF
--- a/src/WeChat/Utility.php
+++ b/src/WeChat/Utility.php
@@ -51,11 +51,14 @@ class Utility
      */
     private function getSignContent(array $data): string
     {
+       return  urldecode(http_build_query($data));
+       /*
         $buff = '';
         foreach ($data as $k => $v) {
             $buff .= ($k != 'sign' && $v != '' && !is_array($v)) ? $k . '=' . $v . '&' : '';
         }
         return trim($buff, '&');
+       */
     }
 
     /**
@@ -94,7 +97,7 @@ class Utility
         $bean->setAppId($this->config->getAppId());
         $bean->setMchId($this->config->getMchId());
         $bean->setSign($this->generateSign($bean->toArray()));
-        $response = NewWork::postXML($this->config->getGateWay() . $endpoint, (new SplArray($bean->toArray()))->toXML(), $useCert ? [
+        $response = NewWork::postXML($this->config->getGateWay() . $endpoint, (new SplArray($bean->toArray()))->toXML(true), $useCert ? [
             'ssl_cert_file' => $this->config->getApiClientCert(),
             'ssl_key_file' => $this->config->getApiClientKey()]
             : []);


### PR DESCRIPTION
签名内容使用http_build_query，并做了urldecode。
拼接XML时默认使用cdata，用来去除特殊字符