### PR TITLE
fix wechat pay sign generate and check bug

### DIFF
--- a/src/WeChat/Utility.php
+++ b/src/WeChat/Utility.php
@@ -52,6 +52,11 @@ class Utility
     private function getSignContent(array $data): string
     {
         unset($data['sign']);
+        foreach ($data as $key => $value) {
+            if ($value === null || $value === '') {
+                unset($data[$key]);
+            }
+        }
         return  urldecode(http_build_query($data));
         /*
          $buff = '';
@@ -80,6 +85,11 @@ class Utility
 
         if (!isset($result['return_code']) || $result['return_code'] != 'SUCCESS' || $result['result_code'] != 'SUCCESS') {
             throw new GatewayException('Get Wechat API Error:' . ($result['return_msg'] ?? $result['retmsg']) . ($result['err_code_des'] ?? ''),$result,$result['return_code']);
+        }
+
+        // 这里为了兼容微信的一个BUG，用请求的sign_type代替响应值里的sign_type
+        if (!isset($result['sign_type']) && $bean->getSignType() != null) {
+            $result['sign_type'] = $bean->getSignType();
         }
         if (strpos($endpoint, 'mmpaymkttransfers') !== false || $this->generateSign($result) === $result['sign']) {
             return new SplArray($result);


### PR DESCRIPTION
* 修复接收微信响应时由于缺少sign_type字段导致验签失败的BUG
* 修复由于微信自动过滤空字符串生成签名导致的验签失败的BUG