### PR TITLE
libxml_disable_entity_loader 兼容 php8

### DIFF
--- a/src/WeChat/Utility.php
+++ b/src/WeChat/Utility.php
@@ -137,7 +137,7 @@ class Utility
         if (!$xml) {
             throw new InvalidArgumentException('Convert To Array Error! Invalid Xml!');
         }
-        libxml_disable_entity_loader(true);
+        if (\PHP_VERSION_ID < 80000 || \LIBXML_VERSION < 20900) libxml_disable_entity_loader(true);
         return json_decode(json_encode(simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA)), true);
     }
 


### PR DESCRIPTION
当网站的运行环境是PHP8或以上的时候，出现以下报错：

```
Deprecated - Function libxml_disable_entity_loader() is deprecated
```

在PHP 8.0和更高版本中，PHP使用 2.9.0 版的 `libxml`，不推荐使用 `libxml_disable_entity_loader`。